### PR TITLE
Replace gradle android publisher with gradle play publisher

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome), [awesome-gul
 - Releasing
   - [gradle-deploygate-plugin](https://github.com/deploygate/gradle-deploygate-plugin) - Build and deploy apps to DeployGate.
   - [testfairy-gradle-plugin](https://github.com/testfairy/testfairy-gradle-plugin) - Official plugin to upload signed builds to TestFairy.
-  - [gradle-android-publisher](https://github.com/bluesliverx/gradle-android-publisher) - Publish APKs to Google Play.
+  - [gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher) - Manage your complete Play Store presence in your repository: Listing, Release Notes, APKs and App Bundles
 - Testing
   - [gradle-plugin-robospock](https://github.com/Centril/gradle-plugin-robospock) - Configure robospock (gradle + spock + roboelectric) easily.
   - [unmock-plugin](https://github.com/bjoernQ/unmock-plugin) - Allow you to use selected classes from a real Android-Jarfile for Android unit testing.

--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome), [awesome-gul
 - Releasing
   - [gradle-deploygate-plugin](https://github.com/deploygate/gradle-deploygate-plugin) - Build and deploy apps to DeployGate.
   - [testfairy-gradle-plugin](https://github.com/testfairy/testfairy-gradle-plugin) - Official plugin to upload signed builds to TestFairy.
-  - [gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher) - Manage your complete Play Store presence in your repository: Listing, Release Notes, APKs and App Bundles
+  - [gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher) - Manage your complete Play Store presence in your repository: Listing, Release Notes, APKs and App Bundles.
 - Testing
   - [gradle-plugin-robospock](https://github.com/Centril/gradle-plugin-robospock) - Configure robospock (gradle + spock + roboelectric) easily.
   - [unmock-plugin](https://github.com/bjoernQ/unmock-plugin) - Allow you to use selected classes from a real Android-Jarfile for Android unit testing.


### PR DESCRIPTION
Link: https://github.com/Triple-T/gradle-play-publisher
Why?
gradle-android-publisher doesn't look like its being maintained anymore whilst gradle play publisher just got a 2.0.0 release, supporting all functions of googles play store API, including the new stuff like app bundles.
Additionally it has a great documentation, detailing not only how to configure the plugin itself but also how to setup the service accounts for authentication etc.
I have used it in several projects and it works great for automatic publishing through CI. [Here](https://github.com/IIIuminator/EnQ) is one such project using it to automatically publish alphas using CircleCI.