### PR TITLE
Add spotless-changelog

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome), [awesome-gul
 - [gradle-bintray-plugin](https://github.com/bintray/gradle-bintray-plugin) - Publish artifacts to Bintray.
 - [gradle-nexus-plugin](https://github.com/bmuschko/gradle-nexus-plugin) - Configure and upload artifacts to Sonatype Nexus.
 - [gradle-release](https://github.com/researchgate/gradle-release) - Automate releasing process. Similar to the Maven release plugin.
+- [spotless-changelog](https://github.com/diffplug/spotless-changelog) - Parses changelog to calculate next version, then updates changelog on publish.
 
 ### Notification
 


### PR DESCRIPTION
It's pretty new, but I've used it a lot over the past few weeks, and it's been really helpful to me.  We're using it now to ship spotless (https://github.com/diffplug/spotless/issues/512), along with 6 other projects.

([twitter release announcement if you'd like to signal boost](https://twitter.com/NedTwigg/status/1217027144737386497?s=20))